### PR TITLE
add: support for html files

### DIFF
--- a/c3p0/gcs.py
+++ b/c3p0/gcs.py
@@ -3,6 +3,11 @@ from google.oauth2 import service_account
 import pandas as pd
 from io import StringIO
 import os
+import re
+
+
+def determineFileType(filename):
+    return re.search("\..*$", filename).group().replace(".", "")
 
 
 def gcsAuth(keyfile):
@@ -34,7 +39,11 @@ def putGCS(credentials, data, project, bucket, file_name, includeIndex=False):
     # TODO: Something like this for JSON. Have to deal with NaNs/None though
     # import json
     # blob.upload_from_string(json.dumps(data.to_dict()))
-    blob.upload_from_string(data.to_csv(index=includeIndex), content_type="text/csv")
+    filetype = determineFileType(file_name)
+    if filetype == "csv":
+        blob.upload_from_string(data.to_csv(index=includeIndex), content_type="text/csv")
+    elif filetype == "html":
+        blob.upload_from_string(data, content_type="text/html")
 
     return {"project": project, "bucket": bucket, "file": file_name}
 

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -1,40 +1,24 @@
-import pytest
 from c3p0 import output
-import numpy as np
 import pandas as pd
 import json
 
-# Test Definitions
+
 def test_output_data():
-    testData = pd.DataFrame(["Paul McCartney", "John Lennon", "George Harrisn", "Ringo Starr"], columns = ["Name"]).to_json()
-
-    outputResult = output(data = testData, logs = [], errors = [])
-
+    testData = pd.DataFrame(["Paul McCartney", "John Lennon", "George Harrisn", "Ringo Starr"], columns=["Name"]).to_json()
+    outputResult = output(data=testData, logs=[], errors=[])
     dataLength = len(pd.DataFrame(json.loads(outputResult['data'])))
     assert dataLength == 4
 
+
 def test_output_logs():
-    testLogs = pd.DataFrame(["This is a test log", "this is a second test log"], columns = ["log"]).to_json()
-
-    outputResult = output(data = [], logs = testLogs, errors = [])
-
+    testLogs = pd.DataFrame(["This is a test log", "this is a second test log"], columns=["log"]).to_json()
+    outputResult = output(data=[], logs=testLogs, errors=[])
     logLength = len(json.loads(outputResult['logs'])['log'])
-
     assert logLength == 2
 
 
 def test_output_errors():
-    testLogs = pd.DataFrame(["This is a test error", "this is a second test", "this is a third test error"],  columns = ["log"]).to_json()
-
-    outputResult = output(data = [], logs = testLogs, errors = [])
-
+    testLogs = pd.DataFrame(["This is a test error", "this is a second test", "this is a third test error"],  columns=["log"]).to_json()
+    outputResult = output(data=[], logs=testLogs, errors=[])
     logLength = len(json.loads(outputResult['logs'])['log'])
-
     assert logLength == 3
-
-
-
-# Run Functions
-test_output_data()
-test_output_logs()
-test_output_errors()


### PR DESCRIPTION
In testing Jinja2 templates, saving files to GCS is needed. This adds support for saving html files without having to specify the file type. Also supports future file type inclusion.